### PR TITLE
Change to `clientId` and `callbackUrl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ passport.deserializeUser((user, done) => {
 passport.use(
   new Strategy(
     {
-      clientID: 'CLIENT_ID',
+      clientId: 'CLIENT_ID',
       clientSecret: 'CLIENT_SECRET',
-      callbackURL: 'http://localhost:3000/auth/discord/callback',
+      callbackUrl: 'http://localhost:3000/auth/discord/callback',
       scope: ['identify', 'guilds'],
     },
     // Do something with the profile


### PR DESCRIPTION
The example is written incorrectly. It should be `clientId` and `callbackUrl` instead of `clientID` and `callbackURL`.

```
Error: The field "clientId" has not been provided.
    at D:\Projects\www\patrons.sefinek.net\node_modules\passport-discord-auth\dist\index.js:1:1729
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

```
Error: The field "callbackUrl" has not been provided.
    at D:\Projects\www\patrons.sefinek.net\node_modules\passport-discord-auth\dist\index.js:1:1729
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Anyway, everything is working correctly. I just had to make a few adjustments to my code.